### PR TITLE
be: fix CORS validation between frontend and backend

### DIFF
--- a/backend/src/main/java/com/remitk/registry/config/CorsConfig.java
+++ b/backend/src/main/java/com/remitk/registry/config/CorsConfig.java
@@ -1,0 +1,30 @@
+package com.remitk.registry.config;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.*;
+
+@Configuration
+public class CorsConfig {
+
+    private final CorsProperties corsProperties;
+
+    public CorsConfig(CorsProperties corsProperties) {
+        this.corsProperties = corsProperties;
+    }
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins(corsProperties.getAllowedOrigins().toArray(new String[0]))
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                        .allowedHeaders("*")
+                        .allowCredentials(true);
+            }
+        };
+    }
+}

--- a/backend/src/main/java/com/remitk/registry/config/CorsProperties.java
+++ b/backend/src/main/java/com/remitk/registry/config/CorsProperties.java
@@ -1,0 +1,21 @@
+package com.remitk.registry.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@ConfigurationProperties(prefix = "app.cors")
+public class CorsProperties {
+
+    private List<String> allowedOrigins;
+
+    public List<String> getAllowedOrigins() {
+        return allowedOrigins;
+    }
+
+    public void setAllowedOrigins(List<String> allowedOrigins) {
+        this.allowedOrigins = allowedOrigins;
+    }
+}

--- a/backend/src/main/java/com/remitk/registry/dto/MicrochipDTO.java
+++ b/backend/src/main/java/com/remitk/registry/dto/MicrochipDTO.java
@@ -12,7 +12,6 @@ public class MicrochipDTO {
     @NotNull
     @Size(max = 255)
     private String importer;
-    @NotNull
     private MicrochipStatus status;
 
     public MicrochipDTO(Long id, String chipNumber, String importer, MicrochipStatus status) {

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -15,3 +15,7 @@ spring:
   flyway:
     enabled: true
     locations: classpath:db/migrations
+
+app:
+  cors:
+    allowed-origins: http://localhost:4200


### PR DESCRIPTION
## Description
Add a field for frontend application into application.yml, this will be used in a Access-Control-Allow-Origin header, so frontend will be happy 

Also, fix MicrochipDTO to allow registering without a status (will always be FREE anyway)

## Type of change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] CI / Infrastructure

## Testing
- [x] Backend builds successfully
- [ ] Frontend builds successfully
- [ ] No new warnings or errors

## Database
- [x] No database changes
- [ ] Migration added (Flyway)

## Checklist
- [x] Code follows project structure
- [ ] Documentation updated if needed
- [ ] PR reviewed by CODEOWNERS