### PR TITLE
be: rename the data carrying part of response JSON DTO to "items"

### DIFF
--- a/backend/src/main/java/com/remitk/registry/dto/MicrochipListDTO.java
+++ b/backend/src/main/java/com/remitk/registry/dto/MicrochipListDTO.java
@@ -3,7 +3,7 @@ package com.remitk.registry.dto;
 import java.util.List;
 
 public class MicrochipListDTO {
-    private final List<MicrochipDTO> microchips;
+    private final List<MicrochipDTO> items;
     private final int page;
     private final int size;
     private final int totalPages;
@@ -11,8 +11,8 @@ public class MicrochipListDTO {
     private final String sortBy;
     private final String direction;
 
-    public MicrochipListDTO(List<MicrochipDTO> microchips, int page, int size, int totalPages, long totalElements, String sortBy, String direction) {
-        this.microchips = microchips;
+    public MicrochipListDTO(List<MicrochipDTO> items, int page, int size, int totalPages, long totalElements, String sortBy, String direction) {
+        this.items = items;
         this.page = page;
         this.size = size;
         this.totalPages = totalPages;
@@ -21,8 +21,8 @@ public class MicrochipListDTO {
         this.direction = direction;
     }
 
-    public List<MicrochipDTO> getMicrochips() {
-        return microchips;
+    public List<MicrochipDTO> getItems() {
+        return items;
     }
 
     public int getPage() {

--- a/backend/src/main/java/com/remitk/registry/dto/OwnerListDTO.java
+++ b/backend/src/main/java/com/remitk/registry/dto/OwnerListDTO.java
@@ -3,7 +3,7 @@ package com.remitk.registry.dto;
 import java.util.List;
 
 public class OwnerListDTO {
-    private final List<OwnerDTO> owners;
+    private final List<OwnerDTO> items;
     private final int page;
     private final int size;
     private final int totalPages;
@@ -11,8 +11,8 @@ public class OwnerListDTO {
     private final String sortBy;
     private final String direction;
 
-    public OwnerListDTO(List<OwnerDTO> owners, int page, int size, int totalPages, long totalElements, String sortBy, String direction) {
-        this.owners = owners;
+    public OwnerListDTO(List<OwnerDTO> items, int page, int size, int totalPages, long totalElements, String sortBy, String direction) {
+        this.items = items;
         this.page = page;
         this.size = size;
         this.totalPages = totalPages;
@@ -21,8 +21,8 @@ public class OwnerListDTO {
         this.direction = direction;
     }
 
-    public List<OwnerDTO> getOwners() {
-        return owners;
+    public List<OwnerDTO> getItems() {
+        return items;
     }
 
     public int getPage() {

--- a/backend/src/main/java/com/remitk/registry/dto/PetListDTO.java
+++ b/backend/src/main/java/com/remitk/registry/dto/PetListDTO.java
@@ -3,7 +3,7 @@ package com.remitk.registry.dto;
 import java.util.List;
 
 public class PetListDTO {
-    private final List<PetDTO> pets;
+    private final List<PetDTO> items;
     private final int page;
     private final int size;
     private final int totalPages;
@@ -11,8 +11,8 @@ public class PetListDTO {
     private final String sortBy;
     private final String direction;
 
-    public PetListDTO(List<PetDTO> pets, int page, int size, int totalPages, long totalElements, String sortBy, String direction) {
-        this.pets = pets;
+    public PetListDTO(List<PetDTO> items, int page, int size, int totalPages, long totalElements, String sortBy, String direction) {
+        this.items = items;
         this.page = page;
         this.size = size;
         this.totalPages = totalPages;
@@ -21,8 +21,8 @@ public class PetListDTO {
         this.direction = direction;
     }
 
-    public List<PetDTO> getPets() {
-        return pets;
+    public List<PetDTO> getItems() {
+        return items;
     }
 
     public int getPage() {


### PR DESCRIPTION
## Description
In the responses that contain several entities, the field that contains the list of entities had its name changed to "items" for consistency. Small change, should be good to merge immediately.

## Type of change
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] CI / Infrastructure

## Testing
- [x] Backend builds successfully
- [ ] Frontend builds successfully
- [ ] No new warnings or errors

## Database
- [x] No database changes
- [ ] Migration added (Flyway)

## Checklist
- [ ] Code follows project structure
- [ ] Documentation updated if needed
- [ ] PR reviewed by CODEOWNERS